### PR TITLE
Fixing symfony 4.3 deprecation and issue #4

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Ekyna\Bundle\PayumMoneticoBundle\DependencyInjection;
 
+use App\Kernel;
 use Ekyna\Component\Payum\Monetico\Api\Api;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -19,6 +20,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
+        if (version_compare(Kernel::VERSION, '4.0.0') >= 0 ) {
+            $treeBuilder = new TreeBuilder('my_bundle');
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $root = $treeBuilder->root('my_bundle');
+        }
         $treeBuilder = new TreeBuilder('ekyna_payum_monetico');
         $root = $treeBuilder->getRootNode();
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,11 +2,11 @@
 
 namespace Ekyna\Bundle\PayumMoneticoBundle\DependencyInjection;
 
-use App\Kernel;
 use Ekyna\Component\Payum\Monetico\Api\Api;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Class Configuration

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,14 +21,12 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         if (version_compare(Kernel::VERSION, '4.0.0') >= 0 ) {
-            $treeBuilder = new TreeBuilder('my_bundle');
+            $treeBuilder = new TreeBuilder('ekyna_payum_monetico');
             $root = $treeBuilder->getRootNode();
         } else {
             $treeBuilder = new TreeBuilder();
-            $root = $treeBuilder->root('my_bundle');
+            $root = $treeBuilder->root('ekyna_payum_monetico');
         }
-        $treeBuilder = new TreeBuilder('ekyna_payum_monetico');
-        $root = $treeBuilder->getRootNode();
 
         $this->addApiSection($root);
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,8 +19,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('ekyna_payum_monetico');
+        $treeBuilder = new TreeBuilder('ekyna_payum_monetico');
+        $root = $treeBuilder->getRootNode();
 
         $this->addApiSection($root);
 


### PR DESCRIPTION
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "ekyna_payum_monetico" configuration is deprecated since Symfony 4.3, the root name is passed to the constructor instead.

[Fixing Issue number 4](https://github.com/ekyna/PayumMoneticoBundle/issues/4)
